### PR TITLE
Fix #12: Add a button to reset the state of the main page

### DIFF
--- a/components/ResetButton.js
+++ b/components/ResetButton.js
@@ -1,0 +1,9 @@
+import Button from './Button'
+
+export default function ResetButton({ callback }) {
+  return (
+    <Button onClick={callback}>
+      Reset State
+    </Button>
+  )
+}

--- a/components/ResetButton.test.js
+++ b/components/ResetButton.test.js
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import ResetButton from './ResetButton'
+
+test('renders a button with the text "Reset State"', () => {
+  const mockCallback = jest.fn()
+  render(<ResetButton callback={mockCallback} />)
+  const button = screen.getByRole('button')
+  expect(button).toHaveTextContent('Reset State')
+})
+
+test('calls the callback prop on click', () => {
+  const mockCallback = jest.fn()
+  render(<ResetButton callback={mockCallback} />)
+  const button = screen.getByRole('button')
+  expect(mockCallback).not.toHaveBeenCalled()
+  fireEvent.click(button)
+  expect(mockCallback).toHaveBeenCalledTimes(1)
+})

--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "^13.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.1",
+    "@testing-library/react": "^14.1.2",
+    "jest": "^27.4.5"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import Button from '../components/Button'
 import ClickCount from '../components/ClickCount'
+import ResetButton from '../components/ResetButton'
 import styles from '../styles/home.module.css'
 
 function throwError() {
@@ -12,9 +13,17 @@ function throwError() {
 
 function Home() {
   const [count, setCount] = useState(0)
+  const [clickCount, setClickCount] = useState(0)
   const increment = useCallback(() => {
     setCount((v) => v + 1)
   }, [setCount])
+  const incrementClick = useCallback(() => {
+    setClickCount((v) => v + 1)
+  }, [setClickCount])
+  const resetState = useCallback(() => {
+    setCount(0)
+    setClickCount(0)
+  }, [setCount, setClickCount])
 
   useEffect(() => {
     const r = setInterval(() => {
@@ -45,7 +54,7 @@ function Home() {
       <hr className={styles.hr} />
       <div>
         <p>Component with state.</p>
-        <ClickCount />
+        <ClickCount value={clickCount} onClick={incrementClick} />
       </div>
       <hr className={styles.hr} />
       <div>
@@ -62,6 +71,7 @@ function Home() {
         >
           Throw an Error
         </Button>
+        <ResetButton callback={resetState} />
       </div>
       <hr className={styles.hr} />
     </main>

--- a/pages/index.test.js
+++ b/pages/index.test.js
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import Home from './index'
+
+jest.useFakeTimers()
+
+test('renders the home page with initial state', () => {
+  render(<Home />)
+  const counter = screen.getByText(/Current value:/)
+  const clickCount = screen.getByText(/Clicks:/)
+  expect(counter).toHaveTextContent('Current value: 0')
+  expect(clickCount).toHaveTextContent('Clicks: 0')
+})
+
+test('increments the click count on click', () => {
+  render(<Home />)
+  const clickCount = screen.getByText(/Clicks:/)
+  const clicksButton = screen.getByRole('button', { name: /Clicks:/ })
+  expect(clickCount).toHaveTextContent('Clicks: 0')
+  fireEvent.click(clicksButton)
+  expect(clickCount).toHaveTextContent('Clicks: 1')
+})
+
+test('resets the state on click', () => {
+  render(<Home />)
+  const counter = screen.getByText(/Current value:/)
+  const clickCount = screen.getByText(/Clicks:/)
+  const clicksButton = screen.getByRole('button', { name: /Clicks:/ })
+  const resetButton = screen.getByRole('button', { name: /Reset State/ })
+  fireEvent.click(clicksButton)
+  jest.advanceTimersByTime(1000)
+  expect(counter).toHaveTextContent('Current value: 1')
+  expect(clickCount).toHaveTextContent('Clicks: 1')
+  fireEvent.click(resetButton)
+  expect(counter).toHaveTextContent('Current value: 0')
+  expect(clickCount).toHaveTextContent('Clicks: 0')
+})


### PR DESCRIPTION
Fixes #12

Add a button to reset the state of the main page

This PR was created with Copilot Workspace (v0.6). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gh/rahulpandita/nextjs-sample/issues/12?shareId=eea0270f-df1a-4d49-8786-d7a88782713c).